### PR TITLE
Use flag.Duration for speed and delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Server:
 $ tron --help
 Usage of tron:
   -deaths=10: Maximum number of deaths before being kicked
-  -delay=2000: Respawn delay (in ms)
+  -delay=2s: Respawn delay
   -height=60: Height of the game world
   -players=4: Maximum number of simultaneous players
   -port=2200: Port to listen for TCP connections on
-  -speed=25: Game tick interval (in ms)
+  -speed=25ms: Game tick interval
   -width=60: Width of the game world
 
 $ tron

--- a/main.go
+++ b/main.go
@@ -9,13 +9,15 @@ import (
 	"github.com/jpillora/ssh-tron/tron"
 )
 
-var port = flag.Int("port", 2200, "Port to listen for TCP connections on")
-var width = flag.Int("width", 60, "Width of the game world")
-var height = flag.Int("height", 60, "Height of the game world")
-var maxplayers = flag.Int("players", 4, "Maximum number of simultaneous players")
-var maxdeaths = flag.Int("deaths", 10, "Maximum number of deaths before being kicked")
-var speed = flag.Int("speed", 25, "Game tick interval (in ms)")
-var delay = flag.Int("delay", 2000, "Respawn delay (in ms)")
+var (
+	port       = flag.Int("port", 2200, "Port to listen for TCP connections on")
+	width      = flag.Int("width", 60, "Width of the game world")
+	height     = flag.Int("height", 60, "Height of the game world")
+	maxplayers = flag.Int("players", 4, "Maximum number of simultaneous players")
+	maxdeaths  = flag.Int("deaths", 10, "Maximum number of deaths before being kicked")
+	speed      = flag.Duration("speed", 25*time.Millisecond, "Game tick interval")
+	delay      = flag.Duration("delay", 2*time.Second, "Respawn delay")
+)
 
 func main() {
 	flag.Parse()

--- a/tron/game.go
+++ b/tron/game.go
@@ -29,7 +29,7 @@ type Game struct {
 	log      func(string, ...interface{})
 }
 
-func NewGame(port, width, height, maxplayers, maxdeaths, speed, delay int) *Game {
+func NewGame(port, width, height, maxplayers, maxdeaths int, speed, delay time.Duration) *Game {
 
 	//create an id pool
 	idPool := make(chan ID, maxplayers)
@@ -39,8 +39,8 @@ func NewGame(port, width, height, maxplayers, maxdeaths, speed, delay int) *Game
 
 	g := &Game{
 		maxplayers, maxdeaths,
-		time.Duration(speed) * time.Millisecond,
-		time.Duration(delay) * time.Millisecond,
+		speed,
+		delay,
 		width + sidebarWidth, height / 2, width, height,
 		NewServer(port, idPool),
 		nil,


### PR DESCRIPTION
It is easy to pass durations using this flag.
For example, 
`ssh-tron -delay=30ms` 
or 
`ssh-tron -delay=2s`
